### PR TITLE
Add client certificate authentication

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -806,6 +806,9 @@ LEVEL = Info
 ;; Allow users to sign-in with a passkey
 ;ENABLE_PASSKEY_AUTHENTICATION = true
 ;;
+;; Allow sign-in using TLS client certificates
+;ENABLE_CLIENT_CERT_AUTHENTICATION = false
+;;
 ;; More detail: https://github.com/gogits/gogs/issues/165
 ;ENABLE_REVERSE_PROXY_AUTHENTICATION = false
 ; Enable this to allow reverse proxy authentication for API requests, the reverse proxy is responsible for ensuring that no CSRF is possible.

--- a/models/auth/source.go
+++ b/models/auth/source.go
@@ -33,6 +33,7 @@ const (
 	DLDAP       // 5
 	OAuth2      // 6
 	SSPI        // 7
+	X509        // 8
 )
 
 // String returns the string name of the LoginType
@@ -53,6 +54,7 @@ var Names = map[Type]string{
 	PAM:    "PAM",
 	OAuth2: "OAuth2",
 	SSPI:   "SPNEGO with SSPI",
+	X509:   "X.509 (Client Certificate)",
 }
 
 // Config represents login config as far as the db is concerned
@@ -273,6 +275,20 @@ func IsSSPIEnabled(ctx context.Context) bool {
 	}.ToConds())
 	if err != nil {
 		log.Error("IsSSPIEnabled: failed to query active SSPI sources: %v", err)
+		return false
+	}
+	return exist
+}
+
+// IsX509Enabled returns true if there is at least one activated login
+// source of type X509
+func IsX509Enabled(ctx context.Context) bool {
+	exist, err := db.Exist[Source](ctx, FindSourcesOptions{
+		IsActive:  optional.Some(true),
+		LoginType: X509,
+	}.ToConds())
+	if err != nil {
+		log.Error("IsX509Enabled: failed to query active X509 sources: %v", err)
 		return false
 	}
 	return exist

--- a/modules/setting/service.go
+++ b/modules/setting/service.go
@@ -54,6 +54,7 @@ var Service = struct {
 	EnableReverseProxyAutoRegister          bool
 	EnableReverseProxyEmail                 bool
 	EnableReverseProxyFullName              bool
+	EnableClientCertAuth                    bool
 	EnableCaptcha                           bool
 	RequireCaptchaForLogin                  bool
 	RequireExternalRegistrationCaptcha      bool
@@ -188,6 +189,7 @@ func loadServiceFrom(rootCfg ConfigProvider) {
 	Service.EnableReverseProxyAutoRegister = sec.Key("ENABLE_REVERSE_PROXY_AUTO_REGISTRATION").MustBool()
 	Service.EnableReverseProxyEmail = sec.Key("ENABLE_REVERSE_PROXY_EMAIL").MustBool()
 	Service.EnableReverseProxyFullName = sec.Key("ENABLE_REVERSE_PROXY_FULL_NAME").MustBool()
+	Service.EnableClientCertAuth = sec.Key("ENABLE_CLIENT_CERT_AUTHENTICATION").MustBool(false)
 	Service.EnableCaptcha = sec.Key("ENABLE_CAPTCHA").MustBool(false)
 	Service.RequireCaptchaForLogin = sec.Key("REQUIRE_CAPTCHA_FOR_LOGIN").MustBool(false)
 	Service.RequireExternalRegistrationCaptcha = sec.Key("REQUIRE_EXTERNAL_REGISTRATION_CAPTCHA").MustBool(Service.EnableCaptcha)

--- a/routers/web/auth/auth.go
+++ b/routers/web/auth/auth.go
@@ -172,6 +172,7 @@ func prepareSignInPageData(ctx *context.Context) {
 	ctx.Data["PageIsSignIn"] = true
 	ctx.Data["PageIsLogin"] = true
 	ctx.Data["EnableSSPI"] = auth.IsSSPIEnabled(ctx)
+	ctx.Data["EnableClientCert"] = auth.IsX509Enabled(ctx)
 	ctx.Data["EnablePasswordSignInForm"] = setting.Service.EnablePasswordSignInForm
 	ctx.Data["EnablePasskeyAuth"] = setting.Service.EnablePasskeyAuth
 

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -105,6 +105,9 @@ func buildAuthGroup() *auth_service.Group {
 	if setting.Service.EnableReverseProxyAuth {
 		group.Add(&auth_service.ReverseProxy{}) // reverse-proxy should before Session, otherwise the header will be ignored if user has login
 	}
+	if setting.Service.EnableClientCertAuth {
+		group.Add(&auth_service.ClientCert{})
+	}
 	group.Add(&auth_service.Session{})
 
 	if setting.IsWindows && auth_model.IsSSPIEnabled(db.DefaultContext) {

--- a/services/auth/clientcert.go
+++ b/services/auth/clientcert.go
@@ -1,0 +1,77 @@
+package auth
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"net/http"
+
+	user_model "code.gitea.io/gitea/models/user"
+	"code.gitea.io/gitea/modules/log"
+	"code.gitea.io/gitea/modules/setting"
+)
+
+// Ensure the struct implements the interface.
+var (
+	_ Method = &ClientCert{}
+)
+
+// ClientCert implements authentication using TLS client certificates.
+type ClientCert struct{}
+
+// Name represents the name of auth method
+func (c *ClientCert) Name() string {
+	return "client_cert"
+}
+
+// Verify authenticates based on TLS client certificates.
+func (c *ClientCert) Verify(req *http.Request, w http.ResponseWriter, store DataStore, sess SessionStore) (*user_model.User, error) {
+	if req.TLS == nil || len(req.TLS.PeerCertificates) == 0 {
+		return nil, nil
+	}
+	cert := req.TLS.PeerCertificates[0]
+
+	var user *user_model.User
+	var err error
+
+	if len(cert.EmailAddresses) > 0 {
+		user, err = user_model.GetUserByEmail(req.Context(), cert.EmailAddresses[0])
+		if err != nil && !user_model.IsErrUserNotExist(err) {
+			log.Error("GetUserByEmail: %v", err)
+			return nil, err
+		}
+	}
+	if user == nil {
+		username := cert.Subject.CommonName
+		if username != "" {
+			user, err = user_model.GetUserByName(req.Context(), username)
+			if err != nil && !user_model.IsErrUserNotExist(err) {
+				log.Error("GetUserByName: %v", err)
+				return nil, err
+			}
+		}
+	}
+
+	if user == nil {
+		return nil, nil
+	}
+
+	detector := newAuthPathDetector(req)
+	if !detector.isAPIPath() && !detector.isAttachmentDownload() && !detector.isGitRawOrAttachOrLFSPath() {
+		if sess != nil && (sess.Get("uid") == nil || sess.Get("uid").(int64) != user.ID) {
+			handleSignIn(w, req, sess, user)
+		}
+	}
+	log.Trace("ClientCert Authorization: Logged in user %-v", user)
+	store.GetData()["EnableClientCert"] = setting.Service.EnableClientCertAuth
+	return user, nil
+}
+
+// ParseCertificate allows building x509 certificate from header if needed.
+func ParseCertificate(pemData string) (*x509.Certificate, error) {
+	block, _ := pem.Decode([]byte(pemData))
+	if block == nil {
+		return nil, errors.New("failed to parse certificate PEM")
+	}
+	return x509.ParseCertificate(block.Bytes)
+}

--- a/services/auth/source/x509/source.go
+++ b/services/auth/source/x509/source.go
@@ -1,0 +1,27 @@
+package x509
+
+import (
+	"code.gitea.io/gitea/models/auth"
+	"code.gitea.io/gitea/modules/json"
+)
+
+// Source holds configuration for X509 client certificate authentication.
+type Source struct {
+	auth.ConfigBase `json:"-"`
+
+	AutoCreateUsers   bool
+	AutoActivateUsers bool
+	DefaultLanguage   string
+}
+
+func (cfg *Source) FromDB(bs []byte) error {
+	return json.UnmarshalHandleDoubleEncode(bs, cfg)
+}
+
+func (cfg *Source) ToDB() ([]byte, error) {
+	return json.Marshal(cfg)
+}
+
+func init() {
+	auth.RegisterTypeConfig(auth.X509, &Source{})
+}


### PR DESCRIPTION
## Summary
- introduce X509 login source type
- add ClientCert auth method
- enable authentication with TLS client certificates
- expose `ENABLE_CLIENT_CERT_AUTHENTICATION` setting

## Testing
- `make lint-backend` *(fails: `make: *** [Makefile:354: lint-go] Error 1`)*
- `go test ./services/auth/... ./models/auth/... ./modules/setting -run TestNonExistent` *(fails to fetch modules)*

------
https://chatgpt.com/codex/tasks/task_e_6843dcf533448322961eb815e46d8f56